### PR TITLE
Fix secret key import with gpg 2.1

### DIFF
--- a/tasks/gpg.yml
+++ b/tasks/gpg.yml
@@ -39,7 +39,7 @@
 
 - name: import private keys
   shell: >
-    echo '{{ lookup('file', item) }}' | gpg --allow-secret-key-import --import && touch {{ duply_backup_lock_directory }}/{{ item | basename }}
+    echo '{{ lookup('file', item) }}' | gpg --allow-secret-key-import --batch --import && touch {{ duply_backup_lock_directory }}/{{ item | basename }}
   args:
     creates: "{{ duply_backup_lock_directory }}/{{ item | basename }}"
   with_items: "{{ duply_backup_gpg_sec_keys }}"


### PR DESCRIPTION
`gpg --import` asks for a password since version 2.1 when importing a
secret key. Unfortunately, this invokes `pinentry`, which is confused by
the lack of a UI and emits an ominous error, which gpg renders verbatim
without mentioning pinentry:

  "gpg: key ...: error sending to agent: Inappropriate ioctl for device"

This commit adds the --batch flag to gpg when importing a secret key to
import the key unaltered, i.e. with the original passphrase, as
suggested here: https://dev.gnupg.org/T2313