### PR TITLE
Fix ansible warning

### DIFF
--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -4,4 +4,4 @@
   become: true
   tasks:
     - name: include tasks
-      include: "{{ playbook_dir }}/../../tests/tasks/pre.yml"
+      include_tasks: "{{ playbook_dir }}/../../tests/tasks/pre.yml"

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -4,4 +4,4 @@
   become: true
   tasks:
     - name: include tasks
-      include: "{{ playbook_dir }}/../../tests/tasks/post.yml"
+      include_tasks: "{{ playbook_dir }}/../../tests/tasks/post.yml"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 # tasks file
 ---
-- include: configuration.yml
-- include: gpg.yml
-- include: jobs.yml
+- include_tasks: configuration.yml
+- include_tasks: gpg.yml
+- include_tasks: jobs.yml

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -7,9 +7,9 @@
     - name: include vars
       include_vars: "{{ playbook_dir }}/vars/main.yml"
     - name: include tasks
-      include: "{{ playbook_dir }}/tasks/pre.yml"
+      include_tasks: "{{ playbook_dir }}/tasks/pre.yml"
   roles:
     - ../../
   post_tasks:
     - name: include tasks
-      include: "{{ playbook_dir }}/tasks/post.yml"
+      include_tasks: "{{ playbook_dir }}/tasks/post.yml"

--- a/tests/vagrant.yml
+++ b/tests/vagrant.yml
@@ -7,9 +7,9 @@
     - name: include vars
       include_vars: "{{ playbook_dir }}/vars/main.yml"
     - name: include tasks
-      include: "{{ playbook_dir }}/tasks/pre.yml"
+      include_tasks: "{{ playbook_dir }}/tasks/pre.yml"
   roles:
     - ../../
   post_tasks:
     - name: include tasks
-      include: "{{ playbook_dir }}/tasks/post.yml"
+      include_tasks: "{{ playbook_dir }}/tasks/post.yml"


### PR DESCRIPTION
Warning when using role : 
`[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead. This feature will be removed in version 2.16. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.`

Soon to be deprecated 'include' keyword should not be used any more
Replaced all occurences by include_tasks