### PR TITLE
Templated duply scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,10 @@ None
 * `duply_backup_profiles.key.conf.time_separator`: Enables duplicity `--time-separator` option (**optional**, **deprecated**, set to `true` to enable)
 * `duply_backup_profiles.key.conf.short_filenames`: Enables duplicity `--short-filenames` option (**optional**, **deprecated**, set to `true` to enable)
 * `duply_backup_profiles.key.conf.dupl_params`: Additional duplicity command line options. Don't forget to leave a separating space char at the end (**optional**)
-* `duply_backup_profiles.key.pre`: Pre script (**optional**)
-* `duply_backup_profiles.key.post`: Post script (**optional**)
+* `duply_backup_profiles.key.pre`: Pre script; if set tpre is ignored (**optional**)
+* `duply_backup_profiles.key.post`: Post script; if set tpost is ignored (**optional**)
+* `duply_backup_profiles.key.tpre`: Pre script created from Ansible template (**optional**)
+* `duply_backup_profiles.key.tpost`: Post script created from Ansible template (**optional**)
 * `duply_backup_profiles.key.excludes`: A list of glob patterns of included or excluded files / folders (**optional**)
 
 * `duply_backup_gpg_pub_keys`: [default: `[]`]: Public keys to import

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -27,7 +27,7 @@
     path: "{{ duply_backup_profile_directory }}/{{ item.key }}/pre"
     state: absent
   with_dict: "{{ duply_backup_profiles }}"
-  when: item.value.pre is not defined or not item.value.pre
+  when: (item.value.pre is not defined or not item.value.pre) or (item.value.tpre is not defined or not item.value.tpre)
   tags:
     - duply-backup-configuration-profile-pre
 
@@ -45,12 +45,28 @@
   tags:
     - duply-backup-configuration-profile-pre
 
+- name: template dynamic pre scripts
+  ansible.builtin.template:
+    src: "{{ item.value.tpre }}.j2"
+    dest: "{{ duply_backup_profile_directory }}/{{ item.key }}/pre"
+    owner: root
+    group: root
+    mode: 0700
+  with_dict: "{{ duply_backup_profiles }}"
+  when:
+    - item.value.tpre is defined
+    - item.value.tpre
+    # Don't install templated version if static version is defined
+    - item.value.pre is not defined
+  tags:
+    - duply-backup-configuration-profile-pre
+
 - name: remove obsolete post scripts
   ansible.builtin.file:
     path: "{{ duply_backup_profile_directory }}/{{ item.key }}/post"
     state: absent
   with_dict: "{{ duply_backup_profiles }}"
-  when: item.value.post is not defined or not item.value.post
+  when: (item.value.post is not defined or not item.value.post) or (item.value.tpost is not defined or not item.value.tpost)
   tags:
     - duply-backup-configuration-profile-post
 
@@ -65,6 +81,22 @@
   when:
     - item.value.post is defined
     - item.value.post
+  tags:
+    - duply-backup-configuration-profile-post
+
+- name: template dynamic post scripts
+  ansible.builtin.template:
+    src: "{{ item.value.tpost }}.j2"
+    dest: "{{ duply_backup_profile_directory }}/{{ item.key }}/post"
+    owner: root
+    group: root
+    mode: 0700
+  with_dict: "{{ duply_backup_profiles }}"
+  when:
+    - item.value.tpost is defined
+    - item.value.tpost
+    # Don't install templated version if static version is defined
+    - item.post is not defined
   tags:
     - duply-backup-configuration-profile-post
 

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -47,7 +47,7 @@
 
 - name: template dynamic pre scripts
   ansible.builtin.template:
-    src: "{{ item.value.tpre }}.j2"
+    src: "{{ item.value.tpre }}"
     dest: "{{ duply_backup_profile_directory }}/{{ item.key }}/pre"
     owner: root
     group: root
@@ -86,7 +86,7 @@
 
 - name: template dynamic post scripts
   ansible.builtin.template:
-    src: "{{ item.value.tpost }}.j2"
+    src: "{{ item.value.tpost }}"
     dest: "{{ duply_backup_profile_directory }}/{{ item.key }}/post"
     owner: root
     group: root


### PR DESCRIPTION
 Templated pre and post run scripts
    
 Allows one to configure 'tpre' and 'tpost' values which allow for dynamic script creation.
 No templates are provided since they're likely to be closely tied to the related inventory.
 
I've lightly tested this to confirm it works with templates, is properly optional, and those sorts of things.

I'm not sure I got the logic for "remove obsolete pre scripts" (or post scripts) correct so more testing is required there.

Closes https://github.com/Oefenweb/ansible-duply-backup/issues/24
