### PR TITLE
Make gpg_key completely optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ None
 * `duply_backup_profiles`: [default: `{}`]: Duply backup profiles
 * `duply_backup_profiles.key`: The name of the profile (e.g. `etc`)
 * `duply_backup_profiles.key.conf`: Conf declarations
-* `duply_backup_profiles.key.conf.gpg_key`: Encrypt with key (**optional**, omitting will disable encryption)
+* `duply_backup_profiles.key.conf.gpg_key`: Encrypt with key (**optional**, omitting `gpg_key` but including `gpg_keys_enc` and `gpg_key_sign` will enable separate signing and encrypting keys. Omitting two or more options will disable encryption)
 * `duply_backup_profiles.key.conf.gpg_pw`: Symmetric encryption using passphrase only (**optional**)
 * `duply_backup_profiles.key.conf.gpg_keys_enc`: Public key to encrypt to (**optional**)
 * `duply_backup_profiles.key.conf.gpg_key_sign`: A secret key for signing (**optional**)

--- a/templates/etc/duply/conf.j2
+++ b/templates/etc/duply/conf.j2
@@ -11,6 +11,8 @@
 #  GPG_PW='passphrase' - symmetric encryption using passphrase only
 {% if item.value.conf.gpg_key is defined %}
 GPG_KEY='{{ item.value.conf.gpg_key }}'
+{% elif (item.value.conf.gpg_keys_enc is defined) and (item.value.conf.gpg_key_sign is defined) %}
+# GPG_KEY= not in use; see GPG_KEYS_ENC and GPG_KEY_SIGN below
 {% else %}
 GPG_KEY='disabled'
 {% endif %}


### PR DESCRIPTION
In the current codebase GPG_KEY is set to disabled if gpg_key is unset. This causes a problem because GPG_KEY is completely optional when GPG_KEYS_ENC and GPG_KEY_SIGN are in use together.

This change will comment out GPG_KEY instead of adding it with disabled= to allow GPG_KEYS_ENC and GPG_KEY_SIGN to be used.